### PR TITLE
Update artifacts back button styling

### DIFF
--- a/artifacts.module.css
+++ b/artifacts.module.css
@@ -518,8 +518,8 @@
   width: 54px;
   height: 54px;
   border-radius: 50%;
-  background: var(--accent-color);
-  color: var(--background-color);
+  background: #F0F0F0;
+  color: #838383;
   text-decoration: none;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -532,6 +532,13 @@
 .backButton svg {
   width: 24px;
   height: 24px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .backButton {
+    background: #191919;
+    color: #7B7B7B;
+  }
 }
 
 @keyframes fadeInUp {

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "corner-of-the-internet",
+  "name": "stuttgart",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "corner-of-the-internet",
+  "name": "stuttgart",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Update the back button on the artifacts page with new colors for light and dark modes.

Light mode: #F0F0F0 background, #838383 icon
Dark mode: #191919 background, #7B7B7B icon

Hover effect preserved with existing opacity transition.