### PR TITLE
Update link hover previews to display on right side

### DIFF
--- a/components/ui/link-preview.jsx
+++ b/components/ui/link-preview.jsx
@@ -13,13 +13,75 @@ export const LinkPreview = ({
   children,
   url,
   className,
-  width = 200,
-  height = 125,
   quality = 50,
-  layout = "fixed",
   isStatic = false,
   imageSrc = "",
 }) => {
+  const [isOpen, setOpen] = React.useState(false);
+  const [isMounted, setIsMounted] = React.useState(false);
+  const [isMobile, setIsMobile] = React.useState(false);
+  const triggerRef = React.useRef(null);
+  const [position, setPosition] = React.useState({ top: 0, left: 0 });
+  const [dimensions, setDimensions] = React.useState({ width: 350, height: 220 });
+
+  // Calculate dynamic dimensions based on available space while preserving aspect ratio
+  const calculateDimensions = React.useCallback(() => {
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const edgePadding = 60; // Padding from viewport edges
+    // Container adds: 8px padding * 2 + 2px border * 2 = 20px to each dimension
+    const containerExtra = 20;
+
+    // Text container is max-width 450px + 20px body padding on each side
+    const textContainerRight = Math.min(450 + 40, viewportWidth * 0.4);
+    const spacing = 40;
+
+    // Available space for the entire container (image + padding + border)
+    const totalAvailableWidth = viewportWidth - textContainerRight - spacing - edgePadding;
+    const totalAvailableHeight = viewportHeight - (edgePadding * 2);
+
+    // Available space for just the image
+    const availableWidth = totalAvailableWidth - containerExtra;
+    const availableHeight = totalAvailableHeight - containerExtra;
+
+    // Original aspect ratio is 200:125 = 1.6:1
+    const aspectRatio = 1.6;
+
+    // Calculate dimensions that fit within available space while preserving aspect ratio
+    let width = availableWidth;
+    let height = width / aspectRatio;
+
+    // If height exceeds available height, constrain by height instead
+    if (height > availableHeight) {
+      height = availableHeight;
+      width = height * aspectRatio;
+    }
+
+    return {
+      width: Math.max(Math.floor(width), 200),
+      height: Math.max(Math.floor(height), 125),
+    };
+  }, []);
+
+  React.useEffect(() => {
+    setIsMounted(true);
+    const checkMobile = () => setIsMobile(window.innerWidth <= 768);
+    const updateDimensions = () => {
+      setDimensions(calculateDimensions());
+    };
+
+    checkMobile();
+    updateDimensions();
+
+    window.addEventListener('resize', checkMobile);
+    window.addEventListener('resize', updateDimensions);
+    return () => {
+      window.removeEventListener('resize', checkMobile);
+      window.removeEventListener('resize', updateDimensions);
+    };
+  }, [calculateDimensions]);
+
+  // For microlink API (when not using static images)
   let src;
   if (!isStatic) {
     const params = encode({
@@ -30,52 +92,62 @@ export const LinkPreview = ({
       colorScheme: "dark",
       "viewport.isMobile": true,
       "viewport.deviceScaleFactor": 1,
-      "viewport.width": width * 3,
-      "viewport.height": height * 3,
+      "viewport.width": dimensions.width * 2,
+      "viewport.height": dimensions.height * 2,
     });
     src = `https://api.microlink.io/?${params}`;
   } else {
     src = imageSrc;
   }
 
-  const [isOpen, setOpen] = React.useState(false);
-  const [isMounted, setIsMounted] = React.useState(false);
-  const triggerRef = React.useRef(null);
-  const [position, setPosition] = React.useState({ top: 0, left: 0 });
-
-  React.useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
   const springConfig = { stiffness: 300, damping: 30 };
   const x = useMotionValue(0);
+  const y = useMotionValue(0);
   const translateX = useSpring(x, springConfig);
+  const translateY = useSpring(y, springConfig);
 
   const updatePosition = React.useCallback(() => {
     if (!triggerRef.current) return;
-    
+
     const rect = triggerRef.current.getBoundingClientRect();
-    const spacing = 8; // Reduced spacing to bring it closer
-    let top = rect.top - height - spacing;
-    let left = rect.left + rect.width / 2 - width / 2;
-    
-    // Keep card within viewport bounds
     const viewportWidth = window.innerWidth;
-    
-    // Adjust horizontal position if it goes off screen
-    if (left < spacing) {
-      left = spacing;
-    } else if (left + width > viewportWidth - spacing) {
-      left = viewportWidth - width - spacing;
+    const viewportHeight = window.innerHeight;
+    const edgePadding = 60;
+    const containerExtra = 20; // padding (16) + border (4)
+
+    // Desktop: position on the right side of the page, filling available space
+    if (!isMobile) {
+      // Text container is max-width 450px + 20px body padding on each side
+      const textContainerRight = Math.min(450 + 40, viewportWidth * 0.4);
+      const spacing = 40;
+
+      const left = textContainerRight + spacing;
+      // Vertically center the container in the viewport
+      const totalHeight = dimensions.height + containerExtra;
+      const top = Math.max(edgePadding, (viewportHeight - totalHeight) / 2);
+
+      setPosition({ top, left });
+    } else {
+      // Mobile: fall back to original above/below positioning
+      const spacing = 8;
+      const mobileWidth = 280;
+      const mobileHeight = 175;
+      let top = rect.top - mobileHeight - spacing;
+      let left = rect.left + rect.width / 2 - mobileWidth / 2;
+
+      if (left < spacing) {
+        left = spacing;
+      } else if (left + mobileWidth > viewportWidth - spacing) {
+        left = viewportWidth - mobileWidth - spacing;
+      }
+
+      if (top < spacing) {
+        top = rect.bottom + spacing;
+      }
+
+      setPosition({ top, left });
     }
-    
-    // If card would go above viewport, show it below instead
-    if (top < spacing) {
-      top = rect.bottom + spacing;
-    }
-    
-    setPosition({ top, left });
-  }, [width, height]);
+  }, [isMobile, dimensions.height]);
 
   const handleMouseMove = (event) => {
     if (!isOpen && triggerRef.current) {
@@ -83,9 +155,18 @@ export const LinkPreview = ({
     }
     if (!isOpen) return;
     const targetRect = event.target.getBoundingClientRect();
-    const eventOffsetX = event.clientX - targetRect.left;
-    const offsetFromCenter = (eventOffsetX - targetRect.width / 2) / 2;
-    x.set(offsetFromCenter);
+
+    if (!isMobile) {
+      // Desktop: vertical parallax for right-side positioning
+      const eventOffsetY = event.clientY - targetRect.top;
+      const offsetFromCenter = (eventOffsetY - targetRect.height / 2) / 4;
+      y.set(offsetFromCenter);
+    } else {
+      // Mobile: horizontal parallax
+      const eventOffsetX = event.clientX - targetRect.left;
+      const offsetFromCenter = (eventOffsetX - targetRect.width / 2) / 2;
+      x.set(offsetFromCenter);
+    }
   };
 
   const handleMouseEnter = () => {
@@ -95,8 +176,12 @@ export const LinkPreview = ({
 
   const handleMouseLeave = () => {
     setOpen(false);
-    x.set(0); // Reset horizontal offset
+    x.set(0);
+    y.set(0);
   };
+
+  const displayWidth = isMobile ? 280 : dimensions.width;
+  const displayHeight = isMobile ? 175 : dimensions.height;
 
   return (
     <>
@@ -104,10 +189,10 @@ export const LinkPreview = ({
         <div style={{ display: "none" }}>
           <Image
             src={src}
-            width={width}
-            height={height}
+            width={displayWidth}
+            height={displayHeight}
             quality={quality}
-            layout={layout}
+            layout="fixed"
             priority={true}
             alt="hidden image"
           />
@@ -130,9 +215,10 @@ export const LinkPreview = ({
         <AnimatePresence>
           {isOpen && (
             <motion.div
-              initial={{ opacity: 0, y: 10, scale: 0.95 }}
+              initial={isMobile ? { opacity: 0, y: 10, scale: 0.95 } : { opacity: 0, x: 20, scale: 0.95 }}
               animate={{
                 opacity: 1,
+                x: 0,
                 y: 0,
                 scale: 1,
                 transition: {
@@ -142,9 +228,16 @@ export const LinkPreview = ({
                   mass: 0.5,
                 },
               }}
-              exit={{
+              exit={isMobile ? {
                 opacity: 0,
                 y: 10,
+                scale: 0.95,
+                transition: {
+                  duration: 0.15,
+                },
+              } : {
+                opacity: 0,
+                x: 20,
                 scale: 0.95,
                 transition: {
                   duration: 0.15,
@@ -154,11 +247,10 @@ export const LinkPreview = ({
                 position: "fixed",
                 top: `${position.top}px`,
                 left: `${position.left}px`,
-                boxShadow: "0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)",
-                borderRadius: "12px",
+                borderRadius: "16px",
                 zIndex: 50,
                 pointerEvents: "none",
-                x: translateX,
+                ...(isMobile ? { x: translateX } : { y: translateY }),
               }}
             >
               <a
@@ -167,11 +259,11 @@ export const LinkPreview = ({
                 rel="noopener noreferrer"
                 style={{
                   display: "block",
-                  padding: "4px",
+                  padding: "8px",
                   backgroundColor: "white",
                   border: "2px solid transparent",
-                  boxShadow: "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)",
-                  borderRadius: "12px",
+                  boxShadow: "0 4px 40px 0 rgba(0, 0, 0, 0.15)",
+                  borderRadius: "16px",
                   fontSize: 0,
                   textDecoration: "none",
                   pointerEvents: "auto",
@@ -179,12 +271,12 @@ export const LinkPreview = ({
               >
                 <Image
                   src={isStatic ? imageSrc : src}
-                  width={width}
-                  height={height}
+                  width={displayWidth}
+                  height={displayHeight}
                   quality={quality}
-                  layout={layout}
+                  layout="fixed"
                   priority={true}
-                  style={{ borderRadius: "8px", display: "block" }}
+                  style={{ borderRadius: "12px", display: "block", objectFit: "cover" }}
                   alt="preview image"
                 />
               </a>

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "stuttgart",
+  "name": "palenque",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "stuttgart",
+  "name": "palenque",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
Repositioned preview images to appear on the right side of the viewport instead of above/below the link, dynamically filling available white space while maintaining aspect ratio.

## Changes
- Images now display on right side of page with 60px viewport padding
- Dynamically scale to fill available space (preserving 1.6:1 aspect ratio)
- Vertically centered in viewport
- Animation updated: horizontal slide-in from right (desktop) vs vertical slide-up (mobile)
- Parallax effect now vertical on desktop, horizontal on mobile
- Mobile fallback (< 768px) reverts to original above/below positioning

## Testing
- Hover over Procore, SportAI, GEICO links on homepage
- Verify images stay within viewport bounds and have proper spacing
- Test responsive behavior by resizing browser window

🤖 Generated with Claude Code