### PR TITLE
Add hover and press animations to back button

### DIFF
--- a/artifacts.module.css
+++ b/artifacts.module.css
@@ -525,8 +525,19 @@
 }
 
 .backButton:hover {
-  opacity: 0.85;
+  background: #E0E0E0;
+  transform: scale(1.1);
   cursor: pointer;
+}
+
+.backButton:active {
+  transform: scale(0.95);
+}
+
+@media (prefers-color-scheme: dark) {
+  .backButton:hover {
+    background: #2a2a2a;
+  }
 }
 
 .backButton svg {

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "palenque",
+  "name": "doha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "palenque",
+  "name": "doha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Apply the same hover and press animations from the lightbox buttons to the artifacts page back button. On hover, the button now scales up 1.1x with a subtle background color change. On press, it scales down to 0.95x for tactile feedback.