### PR TITLE
Show arrow icons on mobile nav buttons

### DIFF
--- a/styles.module.css
+++ b/styles.module.css
@@ -458,6 +458,25 @@
     }
 }
 
+/* Mobile: Always show arrow icons since hover doesn't work */
+@media (max-width: 768px) {
+    .navButton {
+        gap: 6px;
+    }
+
+    .navButtonIcon {
+        width: 14px;
+        opacity: 1;
+        transform: translateX(0) translateY(0);
+    }
+
+    .navButtonIconDown {
+        width: 14px;
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
 /* Bottom Logo */
 .logoWrapper {
     display: flex;


### PR DESCRIPTION
On mobile devices, hover states don't work so the arrow icons were
never visible. This adds a media query to always show the arrow icons
for work, artifacts, writing, and reviews buttons on screens <= 768px.

https://claude.ai/code/session_01Q6UHnx6TrwcFgZr3pfTvip