### PR TITLE
add masonry artifacts preview on hover

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -313,61 +313,59 @@ function HomePage() {
                   <polyline points="7 7 17 7 17 17"></polyline>
                 </svg>
               </a>
-              <AnimatePresence mode="wait">
-                {showArtifacts && !isMobile && (
-                  <motion.div
-                    key={artifactsKey}
-                    className={styles.artifactsPreview}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 0.15 }}
+              {showArtifacts && !isMobile && (
+                <motion.div
+                  key={artifactsKey}
+                  className={styles.artifactsPreview}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.1 }}
+                  style={{
+                    position: "fixed",
+                    top: `${artifactsPosition.top}px`,
+                    left: `${artifactsPosition.left}px`,
+                    zIndex: 50,
+                    pointerEvents: "none",
+                  }}
+                >
+                  <div
+                    className={styles.artifactsMasonry}
                     style={{
-                      position: "fixed",
-                      top: `${artifactsPosition.top}px`,
-                      left: `${artifactsPosition.left}px`,
-                      zIndex: 50,
-                      pointerEvents: "none",
+                      gridTemplateColumns: `repeat(${artifactsDimensions.columns}, ${artifactsDimensions.itemSize}px)`,
+                      width: `${artifactsDimensions.totalGridWidth}px`,
                     }}
                   >
-                    <div
-                      className={styles.artifactsMasonry}
-                      style={{
-                        gridTemplateColumns: `repeat(${artifactsDimensions.columns}, ${artifactsDimensions.itemSize}px)`,
-                        width: `${artifactsDimensions.totalGridWidth}px`,
-                      }}
-                    >
-                      {artifactsPreviewItems.map((artifact, index) => (
-                        <motion.a
-                          key={artifact.id}
-                          href="/artifacts"
-                          className={styles.artifactItem}
-                          initial={{ opacity: 0, y: 60, scale: 0.8 }}
-                          animate={{ opacity: 1, y: 0, scale: 1 }}
-                          transition={{
-                            duration: 0.5,
-                            delay: index * 0.04,
-                            ease: [0.23, 1, 0.32, 1],
-                          }}
-                          style={{
-                            width: `${artifactsDimensions.itemSize}px`,
-                            height: `${artifactsDimensions.itemSize}px`,
-                            pointerEvents: "auto",
-                          }}
-                        >
-                          <Image
-                            src={artifact.image}
-                            alt={artifact.caption}
-                            width={artifactsDimensions.itemSize}
-                            height={artifactsDimensions.itemSize}
-                            className={styles.artifactImage}
-                          />
-                        </motion.a>
-                      ))}
-                    </div>
-                  </motion.div>
-                )}
-              </AnimatePresence>
+                    {artifactsPreviewItems.map((artifact, index) => (
+                      <motion.a
+                        key={artifact.id}
+                        href="/artifacts"
+                        className={styles.artifactItem}
+                        initial={{ opacity: 0, y: 40 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{
+                          duration: 0.3,
+                          delay: index * 0.018,
+                          ease: "easeOut",
+                        }}
+                        style={{
+                          width: `${artifactsDimensions.itemSize}px`,
+                          height: `${artifactsDimensions.itemSize}px`,
+                          pointerEvents: "auto",
+                        }}
+                      >
+                        <Image
+                          src={artifact.image}
+                          alt={artifact.caption}
+                          width={artifactsDimensions.itemSize}
+                          height={artifactsDimensions.itemSize}
+                          className={styles.artifactImage}
+                        />
+                      </motion.a>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
             </div>
             <a
               target="_blank"

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,6 +21,7 @@ function HomePage() {
   const [showReviews, setShowReviews] = useState(false);
   const [isReviewsClosing, setIsReviewsClosing] = useState(false);
   const [showArtifacts, setShowArtifacts] = useState(false);
+  const [artifactsKey, setArtifactsKey] = useState(0);
   const [isMobile, setIsMobile] = useState(false);
   const [artifactsPosition, setArtifactsPosition] = useState({ top: 0, left: 0 });
   const [artifactsDimensions, setArtifactsDimensions] = useState({ columns: 3, itemSize: 120 });
@@ -88,6 +89,7 @@ function HomePage() {
   const handleArtifactsMouseEnter = () => {
     if (isMobile) return;
     updateArtifactsLayout();
+    setArtifactsKey(prev => prev + 1);
     setShowArtifacts(true);
   };
 
@@ -311,14 +313,15 @@ function HomePage() {
                   <polyline points="7 7 17 7 17 17"></polyline>
                 </svg>
               </a>
-              <AnimatePresence>
+              <AnimatePresence mode="wait">
                 {showArtifacts && !isMobile && (
                   <motion.div
+                    key={artifactsKey}
                     className={styles.artifactsPreview}
-                    initial={{ opacity: 0, x: 20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: 20 }}
-                    transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.15 }}
                     style={{
                       position: "fixed",
                       top: `${artifactsPosition.top}px`,
@@ -339,13 +342,12 @@ function HomePage() {
                           key={artifact.id}
                           href="/artifacts"
                           className={styles.artifactItem}
-                          initial={{ opacity: 0, y: 30 }}
-                          animate={{ opacity: 1, y: 0 }}
-                          exit={{ opacity: 0, y: 20 }}
+                          initial={{ opacity: 0, y: 60, scale: 0.8 }}
+                          animate={{ opacity: 1, y: 0, scale: 1 }}
                           transition={{
-                            duration: 0.4,
-                            delay: index * 0.05,
-                            ease: [0.34, 1.56, 0.64, 1],
+                            duration: 0.5,
+                            delay: index * 0.04,
+                            ease: [0.23, 1, 0.32, 1],
                           }}
                           style={{
                             width: `${artifactsDimensions.itemSize}px`,

--- a/pages/index.js
+++ b/pages/index.js
@@ -24,10 +24,18 @@ function HomePage() {
   const [isArtifactsClosing, setIsArtifactsClosing] = useState(false);
   const [artifactsKey, setArtifactsKey] = useState(0);
   const [isMobile, setIsMobile] = useState(false);
-  const [artifactsPosition, setArtifactsPosition] = useState({ top: 0, left: 0 });
-  const [artifactsDimensions, setArtifactsDimensions] = useState({ columns: 3, itemSize: 120 });
+  const [artifactsPosition, setArtifactsPosition] = useState({
+    top: 0,
+    left: 0,
+  });
+  const [artifactsDimensions, setArtifactsDimensions] = useState({
+    columns: 3,
+    itemSize: 120,
+  });
   const [imagesPreloaded, setImagesPreloaded] = useState(false);
-  const artifactsPreviewItems = artifacts.filter(a => !a.featured).slice(0, 12);
+  const artifactsPreviewItems = artifacts
+    .filter((a) => !a.featured)
+    .slice(0, 12);
 
   const calculateArtifactsLayout = useCallback(() => {
     const viewportWidth = window.innerWidth;
@@ -45,7 +53,7 @@ function HomePage() {
 
     // Calculate optimal columns and item size
     const minItemSize = 80;
-    const maxItemSize = 140;
+    const maxItemSize = 200;
     let columns = Math.floor((availableWidth + gap) / (minItemSize + gap));
     columns = Math.max(2, Math.min(columns, 4));
 
@@ -94,7 +102,7 @@ function HomePage() {
       setIsArtifactsClosing(false);
     }
     updateArtifactsLayout();
-    setArtifactsKey(prev => prev + 1);
+    setArtifactsKey((prev) => prev + 1);
     setShowArtifacts(true);
   };
 
@@ -333,7 +341,10 @@ function HomePage() {
               onMouseEnter={handleArtifactsMouseEnter}
               onMouseLeave={handleArtifactsMouseLeave}
             >
-              <a href="/artifacts" className={`${styles.navButton} ${showArtifacts ? styles.artifactsButtonActive : ""}`}>
+              <a
+                href="/artifacts"
+                className={`${styles.navButton} ${showArtifacts ? styles.artifactsButtonActive : ""}`}
+              >
                 <span>Artifacts</span>
                 <svg
                   className={styles.navButtonIcon}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import Image from "next/image";
 import dynamic from "next/dynamic";
+import { motion, AnimatePresence } from "framer-motion";
 import styles from "../styles.module.css";
 import { LinkPreview } from "../components/ui/link-preview";
 import { reviews } from "../data/reviews";
@@ -20,9 +21,53 @@ function HomePage() {
   const [showReviews, setShowReviews] = useState(false);
   const [isReviewsClosing, setIsReviewsClosing] = useState(false);
   const [showArtifacts, setShowArtifacts] = useState(false);
-  const [isArtifactsClosing, setIsArtifactsClosing] = useState(false);
-  const artifactsTimeoutRef = useRef(null);
+  const [isMobile, setIsMobile] = useState(false);
+  const [artifactsPosition, setArtifactsPosition] = useState({ top: 0, left: 0 });
+  const [artifactsDimensions, setArtifactsDimensions] = useState({ columns: 3, itemSize: 120 });
   const artifactsPreviewItems = artifacts.filter(a => !a.featured).slice(0, 12);
+
+  const calculateArtifactsLayout = useCallback(() => {
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const edgePadding = 60;
+    const gap = 8;
+
+    // Text container is max-width 450px + 20px body padding on each side
+    const textContainerRight = Math.min(450 + 40, viewportWidth * 0.4);
+    const spacing = 40;
+
+    const left = textContainerRight + spacing;
+    const availableWidth = viewportWidth - left - edgePadding;
+    const availableHeight = viewportHeight - edgePadding * 2;
+
+    // Calculate optimal columns and item size
+    const minItemSize = 80;
+    const maxItemSize = 140;
+    let columns = Math.floor((availableWidth + gap) / (minItemSize + gap));
+    columns = Math.max(2, Math.min(columns, 4));
+
+    let itemSize = Math.floor((availableWidth - (columns - 1) * gap) / columns);
+    itemSize = Math.max(minItemSize, Math.min(itemSize, maxItemSize));
+
+    // Recalculate columns based on actual item size
+    const totalGridWidth = columns * itemSize + (columns - 1) * gap;
+    const rows = Math.ceil(artifactsPreviewItems.length / columns);
+    const totalGridHeight = rows * itemSize + (rows - 1) * gap;
+
+    // Center vertically
+    const top = Math.max(edgePadding, (viewportHeight - totalGridHeight) / 2);
+
+    return {
+      position: { top, left },
+      dimensions: { columns, itemSize, totalGridWidth },
+    };
+  }, [artifactsPreviewItems.length]);
+
+  const updateArtifactsLayout = useCallback(() => {
+    const layout = calculateArtifactsLayout();
+    setArtifactsPosition(layout.position);
+    setArtifactsDimensions(layout.dimensions);
+  }, [calculateArtifactsLayout]);
 
   const handleReviewsToggle = () => {
     if (showReviews) {
@@ -41,22 +86,13 @@ function HomePage() {
   };
 
   const handleArtifactsMouseEnter = () => {
-    if (artifactsTimeoutRef.current) {
-      clearTimeout(artifactsTimeoutRef.current);
-      artifactsTimeoutRef.current = null;
-    }
-    if (isArtifactsClosing) {
-      setIsArtifactsClosing(false);
-    }
+    if (isMobile) return;
+    updateArtifactsLayout();
     setShowArtifacts(true);
   };
 
   const handleArtifactsMouseLeave = () => {
-    setIsArtifactsClosing(true);
-    artifactsTimeoutRef.current = setTimeout(() => {
-      setShowArtifacts(false);
-      setIsArtifactsClosing(false);
-    }, artifactsPreviewItems.length * 50 + 200);
+    setShowArtifacts(false);
   };
 
   useEffect(() => {
@@ -77,12 +113,24 @@ function HomePage() {
       setIsDarkMode(e.matches);
     };
 
+    // Mobile detection and layout updates
+    const checkMobile = () => setIsMobile(window.innerWidth <= 768);
+    checkMobile();
+    updateArtifactsLayout();
+
+    const handleResize = () => {
+      checkMobile();
+      updateArtifactsLayout();
+    };
+
     mediaQuery.addEventListener("change", handleColorSchemeChange);
+    window.addEventListener("resize", handleResize);
 
     return () => {
       mediaQuery.removeEventListener("change", handleColorSchemeChange);
+      window.removeEventListener("resize", handleResize);
     };
-  }, []);
+  }, [updateArtifactsLayout]);
 
   return (
     <div className={`${styles.container} ${isLoaded ? styles.loaded : ""}`}>
@@ -246,7 +294,7 @@ function HomePage() {
               onMouseEnter={handleArtifactsMouseEnter}
               onMouseLeave={handleArtifactsMouseLeave}
             >
-              <a href="/artifacts" className={`${styles.navButton} ${showArtifacts && !isArtifactsClosing ? styles.artifactsButtonActive : ""}`}>
+              <a href="/artifacts" className={`${styles.navButton} ${showArtifacts ? styles.artifactsButtonActive : ""}`}>
                 <span>Artifacts</span>
                 <svg
                   className={styles.navButtonIcon}
@@ -263,31 +311,61 @@ function HomePage() {
                   <polyline points="7 7 17 7 17 17"></polyline>
                 </svg>
               </a>
-              {showArtifacts && (
-                <div className={styles.artifactsPreview}>
-                  <div className={styles.artifactsMasonry}>
-                    {artifactsPreviewItems.map((artifact, index) => (
-                      <a
-                        key={artifact.id}
-                        href="/artifacts"
-                        className={`${styles.artifactItem} ${isArtifactsClosing ? styles.artifactItemClosing : ""}`}
-                        style={{
-                          "--stagger-delay": `${index * 0.15}s`,
-                          "--close-delay": `${(artifactsPreviewItems.length - 1 - index) * 0.05}s`,
-                        }}
-                      >
-                        <Image
-                          src={artifact.image}
-                          alt={artifact.caption}
-                          width={150}
-                          height={150}
-                          className={styles.artifactImage}
-                        />
-                      </a>
-                    ))}
-                  </div>
-                </div>
-              )}
+              <AnimatePresence>
+                {showArtifacts && !isMobile && (
+                  <motion.div
+                    className={styles.artifactsPreview}
+                    initial={{ opacity: 0, x: 20 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    exit={{ opacity: 0, x: 20 }}
+                    transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+                    style={{
+                      position: "fixed",
+                      top: `${artifactsPosition.top}px`,
+                      left: `${artifactsPosition.left}px`,
+                      zIndex: 50,
+                      pointerEvents: "none",
+                    }}
+                  >
+                    <div
+                      className={styles.artifactsMasonry}
+                      style={{
+                        gridTemplateColumns: `repeat(${artifactsDimensions.columns}, ${artifactsDimensions.itemSize}px)`,
+                        width: `${artifactsDimensions.totalGridWidth}px`,
+                      }}
+                    >
+                      {artifactsPreviewItems.map((artifact, index) => (
+                        <motion.a
+                          key={artifact.id}
+                          href="/artifacts"
+                          className={styles.artifactItem}
+                          initial={{ opacity: 0, y: 30 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          exit={{ opacity: 0, y: 20 }}
+                          transition={{
+                            duration: 0.4,
+                            delay: index * 0.05,
+                            ease: [0.34, 1.56, 0.64, 1],
+                          }}
+                          style={{
+                            width: `${artifactsDimensions.itemSize}px`,
+                            height: `${artifactsDimensions.itemSize}px`,
+                            pointerEvents: "auto",
+                          }}
+                        >
+                          <Image
+                            src={artifact.image}
+                            alt={artifact.caption}
+                            width={artifactsDimensions.itemSize}
+                            height={artifactsDimensions.itemSize}
+                            className={styles.artifactImage}
+                          />
+                        </motion.a>
+                      ))}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
             <a
               target="_blank"

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,6 +21,7 @@ function HomePage() {
   const [showReviews, setShowReviews] = useState(false);
   const [isReviewsClosing, setIsReviewsClosing] = useState(false);
   const [showArtifacts, setShowArtifacts] = useState(false);
+  const [isArtifactsClosing, setIsArtifactsClosing] = useState(false);
   const [artifactsKey, setArtifactsKey] = useState(0);
   const [isMobile, setIsMobile] = useState(false);
   const [artifactsPosition, setArtifactsPosition] = useState({ top: 0, left: 0 });
@@ -89,13 +90,20 @@ function HomePage() {
 
   const handleArtifactsMouseEnter = () => {
     if (isMobile) return;
+    if (isArtifactsClosing) {
+      setIsArtifactsClosing(false);
+    }
     updateArtifactsLayout();
     setArtifactsKey(prev => prev + 1);
     setShowArtifacts(true);
   };
 
   const handleArtifactsMouseLeave = () => {
-    setShowArtifacts(false);
+    setIsArtifactsClosing(true);
+    setTimeout(() => {
+      setShowArtifacts(false);
+      setIsArtifactsClosing(false);
+    }, 300);
   };
 
   useEffect(() => {
@@ -365,12 +373,14 @@ function HomePage() {
                       <a
                         key={artifact.id}
                         href="/artifacts"
-                        className={styles.artifactItem}
+                        className={`${styles.artifactItem} ${isArtifactsClosing ? styles.artifactItemClosing : ""}`}
                         style={{
                           width: `${artifactsDimensions.itemSize}px`,
                           height: `${artifactsDimensions.itemSize}px`,
                           pointerEvents: "auto",
-                          animationDelay: `${index * 25}ms`,
+                          animationDelay: isArtifactsClosing
+                            ? `${(artifactsPreviewItems.length - 1 - index) * 15}ms`
+                            : `${index * 25}ms`,
                         }}
                       >
                         {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/pages/index.js
+++ b/pages/index.js
@@ -25,6 +25,7 @@ function HomePage() {
   const [isMobile, setIsMobile] = useState(false);
   const [artifactsPosition, setArtifactsPosition] = useState({ top: 0, left: 0 });
   const [artifactsDimensions, setArtifactsDimensions] = useState({ columns: 3, itemSize: 120 });
+  const [imagesPreloaded, setImagesPreloaded] = useState(false);
   const artifactsPreviewItems = artifacts.filter(a => !a.featured).slice(0, 12);
 
   const calculateArtifactsLayout = useCallback(() => {
@@ -120,6 +121,21 @@ function HomePage() {
     checkMobile();
     updateArtifactsLayout();
 
+    // Preload artifact images for smooth animation
+    const preloadImages = async () => {
+      const imagePromises = artifactsPreviewItems.map((artifact) => {
+        return new Promise((resolve) => {
+          const img = new window.Image();
+          img.onload = resolve;
+          img.onerror = resolve;
+          img.src = artifact.image;
+        });
+      });
+      await Promise.all(imagePromises);
+      setImagesPreloaded(true);
+    };
+    preloadImages();
+
     const handleResize = () => {
       checkMobile();
       updateArtifactsLayout();
@@ -136,6 +152,19 @@ function HomePage() {
 
   return (
     <div className={`${styles.container} ${isLoaded ? styles.loaded : ""}`}>
+      {/* Preload artifact images for smooth hover animation */}
+      <div style={{ display: "none" }} aria-hidden="true">
+        {artifactsPreviewItems.map((artifact) => (
+          <Image
+            key={`preload-${artifact.id}`}
+            src={artifact.image}
+            alt=""
+            width={140}
+            height={140}
+            priority
+          />
+        ))}
+      </div>
       <div className={styles.textContainer}>
         <div className={styles.avatarContainer}>
           <div

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import Image from "next/image";
 import dynamic from "next/dynamic";
 import styles from "../styles.module.css";
 import { LinkPreview } from "../components/ui/link-preview";
 import { reviews } from "../data/reviews";
+import { artifacts } from "../data/artifacts";
 
 const LiquidMetal = dynamic(
   () => import("@paper-design/shaders-react").then((mod) => mod.LiquidMetal),
@@ -18,6 +19,10 @@ function HomePage() {
   const [isAvatarHovered, setIsAvatarHovered] = useState(false);
   const [showReviews, setShowReviews] = useState(false);
   const [isReviewsClosing, setIsReviewsClosing] = useState(false);
+  const [showArtifacts, setShowArtifacts] = useState(false);
+  const [isArtifactsClosing, setIsArtifactsClosing] = useState(false);
+  const artifactsTimeoutRef = useRef(null);
+  const artifactsPreviewItems = artifacts.filter(a => !a.featured).slice(0, 12);
 
   const handleReviewsToggle = () => {
     if (showReviews) {
@@ -33,6 +38,25 @@ function HomePage() {
     } else {
       setShowReviews(true);
     }
+  };
+
+  const handleArtifactsMouseEnter = () => {
+    if (artifactsTimeoutRef.current) {
+      clearTimeout(artifactsTimeoutRef.current);
+      artifactsTimeoutRef.current = null;
+    }
+    if (isArtifactsClosing) {
+      setIsArtifactsClosing(false);
+    }
+    setShowArtifacts(true);
+  };
+
+  const handleArtifactsMouseLeave = () => {
+    setIsArtifactsClosing(true);
+    artifactsTimeoutRef.current = setTimeout(() => {
+      setShowArtifacts(false);
+      setIsArtifactsClosing(false);
+    }, artifactsPreviewItems.length * 50 + 200);
   };
 
   useEffect(() => {
@@ -217,23 +241,54 @@ function HomePage() {
                 <polyline points="7 7 17 7 17 17"></polyline>
               </svg>
             </a>
-            <a href="/artifacts" className={styles.navButton}>
-              <span>Artifacts</span>
-              <svg
-                className={styles.navButtonIcon}
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <line x1="7" y1="17" x2="17" y2="7"></line>
-                <polyline points="7 7 17 7 17 17"></polyline>
-              </svg>
-            </a>
+            <div
+              className={styles.artifactsButtonWrapper}
+              onMouseEnter={handleArtifactsMouseEnter}
+              onMouseLeave={handleArtifactsMouseLeave}
+            >
+              <a href="/artifacts" className={`${styles.navButton} ${showArtifacts && !isArtifactsClosing ? styles.artifactsButtonActive : ""}`}>
+                <span>Artifacts</span>
+                <svg
+                  className={styles.navButtonIcon}
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="7" y1="17" x2="17" y2="7"></line>
+                  <polyline points="7 7 17 7 17 17"></polyline>
+                </svg>
+              </a>
+              {showArtifacts && (
+                <div className={styles.artifactsPreview}>
+                  <div className={styles.artifactsMasonry}>
+                    {artifactsPreviewItems.map((artifact, index) => (
+                      <a
+                        key={artifact.id}
+                        href="/artifacts"
+                        className={`${styles.artifactItem} ${isArtifactsClosing ? styles.artifactItemClosing : ""}`}
+                        style={{
+                          "--stagger-delay": `${index * 0.15}s`,
+                          "--close-delay": `${(artifactsPreviewItems.length - 1 - index) * 0.05}s`,
+                        }}
+                      >
+                        <Image
+                          src={artifact.image}
+                          alt={artifact.caption}
+                          width={150}
+                          height={150}
+                          className={styles.artifactImage}
+                        />
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
             <a
               target="_blank"
               href="https://dannyohana.substack.com/"

--- a/pages/index.js
+++ b/pages/index.js
@@ -343,13 +343,9 @@ function HomePage() {
                 </svg>
               </a>
               {showArtifacts && !isMobile && (
-                <motion.div
+                <div
                   key={artifactsKey}
                   className={styles.artifactsPreview}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={{ duration: 0.1 }}
                   style={{
                     position: "fixed",
                     top: `${artifactsPosition.top}px`,
@@ -366,34 +362,27 @@ function HomePage() {
                     }}
                   >
                     {artifactsPreviewItems.map((artifact, index) => (
-                      <motion.a
+                      <a
                         key={artifact.id}
                         href="/artifacts"
                         className={styles.artifactItem}
-                        initial={{ opacity: 0, y: 40 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{
-                          duration: 0.3,
-                          delay: index * 0.018,
-                          ease: "easeOut",
-                        }}
                         style={{
                           width: `${artifactsDimensions.itemSize}px`,
                           height: `${artifactsDimensions.itemSize}px`,
                           pointerEvents: "auto",
+                          animationDelay: `${index * 25}ms`,
                         }}
                       >
-                        <Image
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img
                           src={artifact.image}
                           alt={artifact.caption}
-                          width={artifactsDimensions.itemSize}
-                          height={artifactsDimensions.itemSize}
                           className={styles.artifactImage}
                         />
-                      </motion.a>
+                      </a>
                     ))}
                   </div>
-                </motion.div>
+                </div>
               )}
             </div>
             <a

--- a/styles.module.css
+++ b/styles.module.css
@@ -372,6 +372,19 @@
     }
 }
 
+.artifactItemClosing {
+    opacity: 1;
+    transform: translateY(0);
+    animation: artifactFlyOut 0.2s cubic-bezier(0.4, 0, 1, 1) forwards;
+}
+
+@keyframes artifactFlyOut {
+    to {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+}
+
 .artifactItem:hover {
     filter: hue-rotate(30deg) saturate(1.2);
 }

--- a/styles.module.css
+++ b/styles.module.css
@@ -344,86 +344,34 @@
 }
 
 .artifactsPreview {
-    position: absolute;
-    top: calc(100% + 12px);
-    left: 0;
-    z-index: 200;
-    background: var(--background-color);
-    border-radius: 16px;
-    padding: 12px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
-    border: 1px solid rgba(0, 0, 0, 0.06);
-}
-
-@media (prefers-color-scheme: dark) {
-    .artifactsPreview {
-        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
-        border: 1px solid rgba(255, 255, 255, 0.08);
-    }
+    /* Position set inline via style prop */
 }
 
 .artifactsMasonry {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
     gap: 8px;
-    width: 320px;
 }
 
 .artifactItem {
     position: relative;
-    border-radius: 8px;
+    border-radius: 12px;
     overflow: hidden;
-    aspect-ratio: 1;
-    opacity: 0;
-    transform: translateY(30px);
-    animation: artifactSlideIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-    animation-delay: var(--stagger-delay, 0s);
     cursor: pointer;
-    transition: filter 0.3s ease;
+    transition: filter 0.3s ease, transform 0.3s ease;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    text-decoration: none;
 }
 
 .artifactItem:hover {
     filter: hue-rotate(30deg) saturate(1.2);
-}
-
-@keyframes artifactSlideIn {
-    0% {
-        opacity: 0;
-        transform: translateY(30px);
-    }
-    100% {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-.artifactItemClosing {
-    opacity: 1;
-    transform: translateY(0);
-    animation: artifactSlideOut 0.2s cubic-bezier(0.4, 0, 1, 1) forwards;
-    animation-delay: var(--close-delay, 0s);
-}
-
-@keyframes artifactSlideOut {
-    0% {
-        opacity: 1;
-        transform: translateY(0);
-    }
-    100% {
-        opacity: 0;
-        transform: translateY(20px);
-    }
+    transform: scale(1.02) !important;
 }
 
 .artifactImage {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    transition: transform 0.3s ease;
-}
-
-.artifactItem:hover .artifactImage {
-    transform: scale(1.05);
+    display: block;
 }
 
 /* Reviews Button */
@@ -576,18 +524,6 @@
         width: 14px;
         opacity: 1;
         transform: translateX(0);
-    }
-
-    /* Hide artifacts preview on mobile - just link to artifacts page */
-    .artifactsPreview {
-        display: none;
-    }
-}
-
-/* Hide artifacts preview on touch devices */
-@media (hover: none) and (pointer: coarse) {
-    .artifactsPreview {
-        display: none;
     }
 }
 

--- a/styles.module.css
+++ b/styles.module.css
@@ -357,14 +357,23 @@
     border-radius: 12px;
     overflow: hidden;
     cursor: pointer;
-    transition: filter 0.3s ease, transform 0.3s ease;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     text-decoration: none;
+    opacity: 0;
+    transform: translateY(50px);
+    animation: artifactFlyIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+    will-change: transform, opacity;
+}
+
+@keyframes artifactFlyIn {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .artifactItem:hover {
     filter: hue-rotate(30deg) saturate(1.2);
-    transform: scale(1.02) !important;
 }
 
 .artifactImage {

--- a/styles.module.css
+++ b/styles.module.css
@@ -324,6 +324,108 @@
     box-shadow: none;
 }
 
+/* Artifacts Preview */
+.artifactsButtonWrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.artifactsButtonActive {
+    background-color: var(--primary-color);
+    color: var(--background-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    gap: 6px;
+}
+
+.artifactsButtonActive .navButtonIcon {
+    width: 14px;
+    opacity: 1;
+    transform: translateX(0) translateY(0);
+}
+
+.artifactsPreview {
+    position: absolute;
+    top: calc(100% + 12px);
+    left: 0;
+    z-index: 200;
+    background: var(--background-color);
+    border-radius: 16px;
+    padding: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+@media (prefers-color-scheme: dark) {
+    .artifactsPreview {
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.2);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+    }
+}
+
+.artifactsMasonry {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+    width: 320px;
+}
+
+.artifactItem {
+    position: relative;
+    border-radius: 8px;
+    overflow: hidden;
+    aspect-ratio: 1;
+    opacity: 0;
+    transform: translateY(30px);
+    animation: artifactSlideIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+    animation-delay: var(--stagger-delay, 0s);
+    cursor: pointer;
+    transition: filter 0.3s ease;
+}
+
+.artifactItem:hover {
+    filter: hue-rotate(30deg) saturate(1.2);
+}
+
+@keyframes artifactSlideIn {
+    0% {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.artifactItemClosing {
+    opacity: 1;
+    transform: translateY(0);
+    animation: artifactSlideOut 0.2s cubic-bezier(0.4, 0, 1, 1) forwards;
+    animation-delay: var(--close-delay, 0s);
+}
+
+@keyframes artifactSlideOut {
+    0% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+}
+
+.artifactImage {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.artifactItem:hover .artifactImage {
+    transform: scale(1.05);
+}
+
 /* Reviews Button */
 .reviewsButtonWrapper {
     position: sticky;
@@ -474,6 +576,18 @@
         width: 14px;
         opacity: 1;
         transform: translateX(0);
+    }
+
+    /* Hide artifacts preview on mobile - just link to artifacts page */
+    .artifactsPreview {
+        display: none;
+    }
+}
+
+/* Hide artifacts preview on touch devices */
+@media (hover: none) and (pointer: coarse) {
+    .artifactsPreview {
+        display: none;
     }
 }
 

--- a/styles.module.css
+++ b/styles.module.css
@@ -354,14 +354,14 @@
 
 .artifactItem {
     position: relative;
-    border-radius: 12px;
-    overflow: hidden;
+    border-radius: 2px;
+    /*overflow: hidden;*/
     cursor: pointer;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    /*box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);*/
     text-decoration: none;
     opacity: 0;
     transform: translateY(50px);
-    animation: artifactFlyIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+    animation: artifactFlyIn 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
     will-change: transform, opacity;
 }
 
@@ -375,7 +375,7 @@
 .artifactItemClosing {
     opacity: 1;
     transform: translateY(0);
-    animation: artifactFlyOut 0.2s cubic-bezier(0.4, 0, 1, 1) forwards;
+    animation: artifactFlyOut 0.05s cubic-bezier(0.4, 0, 1, 1) forwards;
 }
 
 @keyframes artifactFlyOut {
@@ -383,10 +383,6 @@
         opacity: 0;
         transform: translateY(30px);
     }
-}
-
-.artifactItem:hover {
-    filter: hue-rotate(30deg) saturate(1.2);
 }
 
 .artifactImage {


### PR DESCRIPTION
Shows a grid of artifact images when hovering over the Artifacts button.
Features staggered slide-in animation from bottom (0.15s delay between items)
and color shift effect on hover. Hidden on mobile/touch devices.

https://claude.ai/code/session_01DhXW3BV2CQDtT74wrjAbeM