### PR TITLE
Simplify navigation button icon animations and remove hover states

### DIFF
--- a/styles.module.css
+++ b/styles.module.css
@@ -388,33 +388,13 @@
 }
 
 .navButtonIconDown {
-    width: 0;
-    opacity: 0;
-    transform: translateX(-4px);
-    transition:
-        width 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-        opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-        transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.navButton:hover .navButtonIconDown {
     width: 14px;
     opacity: 1;
-    transform: translateX(0);
-}
-
-.reviewsButtonActive {
-    gap: 6px;
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .reviewsButtonActive .navButtonIconDown {
-    width: 14px;
-    opacity: 1;
-    transform: translateX(0) rotate(180deg);
-}
-
-.reviewsButtonActive:hover .navButtonIconDown {
-    transform: translateX(0) rotate(180deg);
+    transform: rotate(180deg);
 }
 
 /* Reviews Section */
@@ -503,15 +483,6 @@
 
     .navButton:hover {
         box-shadow: 0 4px 12px rgba(255, 255, 255, 0.08);
-    }
-}
-
-/* Mobile: Always show down chevron since hover doesn't work */
-@media (max-width: 768px) {
-    .navButtonIconDown {
-        width: 14px;
-        opacity: 1;
-        transform: translateX(0);
     }
 }
 


### PR DESCRIPTION
## Summary
Refactored the navigation button icon animations to simplify the CSS and remove unnecessary hover-based state management. The down chevron icon is now always visible with a fixed width and opacity, eliminating complex transitions and mobile-specific overrides.

## Key Changes
- **Removed hover-dependent animations**: Eliminated `.navButton:hover .navButtonIconDown` selector that previously controlled width, opacity, and transform on hover
- **Simplified icon styling**: Made `.navButtonIconDown` always display with `width: 14px` and `opacity: 1` instead of animating from hidden state
- **Reduced transitions**: Kept only the `transform` transition for the rotate effect, removing unnecessary `width` and `opacity` transitions
- **Removed mobile workaround**: Deleted the `@media (max-width: 768px)` rule that was previously needed to show the icon on mobile devices
- **Cleaned up active state**: Simplified `.reviewsButtonActive .navButtonIconDown` to only handle the `rotate(180deg)` transform, removing redundant width/opacity rules
- **Removed gap styling**: Deleted the `.reviewsButtonActive { gap: 6px; }` rule

## Implementation Details
The changes shift from a "hidden by default, show on hover" pattern to an "always visible" pattern. This simplifies the component behavior and eliminates the need for mobile-specific CSS overrides since hover states don't apply on touch devices anyway.

https://claude.ai/code/session_01G3bA3GF7HCfqxerGMnS2A1